### PR TITLE
fix: 作者头像未设置时在自定义页面不显示

### DIFF
--- a/templates/page.html
+++ b/templates/page.html
@@ -12,7 +12,12 @@
     <div class="rounded-xl bg-white p-4 dark:bg-slate-800">
       <div class="flex items-center justify-between">
         <div class="inline-flex items-center justify-start gap-2" th:with="contributor = ${singlePage.contributors[0]}">
-          <img th:src="${contributor.avatar}" th:alt="${contributor.displayName}" class="h-10 w-10 rounded-full" />
+          <img
+            th:if="${not #strings.isEmpty(contributor.avatar)}"
+            th:src="${contributor.avatar}"
+            th:alt="${contributor.displayName}"
+            class="h-10 w-10 rounded-full"
+          />
           <div class="flex flex-col gap-0.5">
             <span
               class="text-sm font-semibold text-gray-900 dark:text-slate-100"


### PR DESCRIPTION
当作者没有设置头像时不显示图片，与文章模板保持一致。
修改前：
![image](https://user-images.githubusercontent.com/27671436/201887376-7aa7ec72-f193-48a9-b86a-9cc1cd6ff420.png)
修改后：
![image](https://user-images.githubusercontent.com/27671436/201887241-795826fb-589a-44b5-8715-e8a763de45cc.png)
