### PR TITLE
refactor: use literal substitutions to improve th:class and th:text

### DIFF
--- a/templates/category.html
+++ b/templates/category.html
@@ -11,7 +11,7 @@
       th:if="${posts.total gt 0}"
       th:with="postItems=${posts.items},list_layout=${theme.config.layout.post_list_layout}"
       class="mt-6 grid grid-cols-1 gap-6"
-      th:classappend="${list_layout == 'grid_3' ? 'md:grid-cols-2 xl:grid-cols-3' : ''} + ' ' + ${list_layout == 'grid_2' ? 'md:grid-cols-2' : ''}"
+      th:classappend="|${list_layout == 'grid_3' ? 'md:grid-cols-2 xl:grid-cols-3' : ''} ${list_layout == 'grid_2' ? 'md:grid-cols-2' : ''}|"
     >
       <th:block th:each="post : ${postItems}">
         <th:block
@@ -32,7 +32,7 @@
         <span class="i-tabler-arrow-left text-lg transition-all group-hover:-translate-x-1"></span>
         <span>上一页</span>
       </a>
-      <span class="text-sm text-gray-900 dark:text-slate-50" th:text="${posts.page} +' / '+ ${posts.totalPages}"></span>
+      <span class="text-sm text-gray-900 dark:text-slate-50" th:text="|${posts.page} / ${posts.totalPages}|"></span>
       <a
         th:href="@{${posts.nextUrl}}"
         class="whitespace-no-wrap group inline-flex items-center justify-center gap-1 rounded-md border border-gray-200 bg-white px-4 py-1 text-sm font-medium leading-6 text-gray-600 shadow-sm hover:bg-gray-50 focus:shadow-none focus:outline-none dark:border-slate-600 dark:bg-slate-700 dark:text-slate-100 dark:hover:bg-slate-600 dark:hover:text-white"

--- a/templates/index.html
+++ b/templates/index.html
@@ -11,7 +11,7 @@
       th:if="${posts.total gt 0}"
       th:with="postItems=${posts.items},list_layout=${theme.config.layout.post_list_layout}"
       class="mt-6 grid grid-cols-1 gap-6"
-      th:classappend="${list_layout == 'grid_3' ? 'md:grid-cols-2 xl:grid-cols-3' : ''} + ' ' + ${list_layout == 'grid_2' ? 'md:grid-cols-2' : ''}"
+      th:classappend="|${list_layout == 'grid_3' ? 'md:grid-cols-2 xl:grid-cols-3' : ''} ${list_layout == 'grid_2' ? 'md:grid-cols-2' : ''}|"
     >
       <th:block th:each="post : ${postItems}">
         <th:block
@@ -32,7 +32,7 @@
         <span class="i-tabler-arrow-left text-lg transition-all group-hover:-translate-x-1"></span>
         <span>上一页</span>
       </a>
-      <span class="text-sm text-gray-900 dark:text-slate-50" th:text="${posts.page} +' / '+ ${posts.totalPages}"></span>
+      <span class="text-sm text-gray-900 dark:text-slate-50" th:text="|${posts.page} / ${posts.totalPages}|"></span>
       <a
         th:href="@{${posts.nextUrl}}"
         class="whitespace-no-wrap group inline-flex items-center justify-center gap-1 rounded-md border border-gray-200 bg-white px-4 py-1 text-sm font-medium leading-6 text-gray-600 shadow-sm hover:bg-gray-50 focus:shadow-none focus:outline-none dark:border-slate-600 dark:bg-slate-700 dark:text-slate-100 dark:hover:bg-slate-600 dark:hover:text-white"

--- a/templates/modules/featured-post-card.html
+++ b/templates/modules/featured-post-card.html
@@ -28,7 +28,7 @@
         th:each="tag : ${post.tags}"
         th:href="@{${tag.status.permalink}}"
         th:title="${tag.spec.displayName}"
-        th:text="'#'+${tag.spec.displayName}"
+        th:text="|#${tag.spec.displayName}|"
         class="cursor-pointer text-sm italic text-gray-600 hover:text-gray-900 dark:text-slate-400 dark:hover:text-slate-500"
       >
       </a>
@@ -53,7 +53,7 @@
       ></span>
       <span
         class="text-sm tabular-nums text-gray-600 dark:text-slate-300"
-        th:text="${'发布于 '+#dates.format(post.spec.publishTime,'yyyy-MM-dd')}"
+        th:text="|发布于 ${#dates.format(post.spec.publishTime,'yyyy-MM-dd')}|"
       >
       </span>
     </div>

--- a/templates/modules/post-card.html
+++ b/templates/modules/post-card.html
@@ -41,14 +41,14 @@
         th:each="tag : ${post.tags}"
         th:href="@{${tag.status.permalink}}"
         th:title="${tag.spec.displayName}"
-        th:text="'#'+${tag.spec.displayName}"
+        th:text="|#${tag.spec.displayName}|"
         class="cursor-pointer text-sm italic text-gray-600 hover:text-gray-900 dark:text-slate-400 dark:hover:text-slate-500"
       >
       </a>
     </div>
     <h1
       class="cursor-pointer text-2xl font-medium transition-all line-clamp-2 hover:text-gray-500 hover:underline dark:text-slate-50 dark:hover:text-white"
-      th:classappend="${direction == 'column' ? 'sm:line-clamp-2' : ''} + ${list_layout == 'grid_2' ? ' sm:line-clamp-3' : ''} + ${list_layout == 'grid_3' ? ' sm:line-clamp-4' : ''}"
+      th:classappend="|${direction == 'column' ? 'sm:line-clamp-2' : ''} ${list_layout == 'grid_2' ? 'sm:line-clamp-3' : ''} ${list_layout == 'grid_3' ? 'sm:line-clamp-4' : ''}|"
     >
       <a th:href="@{${post.status.permalink}}" th:text="${post.spec.title}" th:title="${post.spec.title}"></a>
     </h1>
@@ -71,7 +71,7 @@
       ></span>
       <span
         class="text-sm tabular-nums text-gray-600 dark:text-slate-300"
-        th:text="${'发布于 '+#dates.format(post.spec.publishTime,'yyyy-MM-dd')}"
+        th:text="|发布于 ${#dates.format(post.spec.publishTime,'yyyy-MM-dd')}|"
       >
       </span>
     </div>

--- a/templates/modules/tag-filter.html
+++ b/templates/modules/tag-filter.html
@@ -11,7 +11,7 @@
       class="rounded bg-gray-100 px-1 py-0.5 text-sm text-gray-900 hover:bg-gray-200 dark:bg-slate-600 dark:text-slate-50 dark:hover:bg-slate-700 dark:hover:text-slate-100"
       th:classappend="(${tag} and ${tag.metadata.name == tagItem.metadata.name}) or (not ${tag} and ${tagStat.index == 0}) ? '!bg-gray-200 dark:!bg-slate-700 dark:!text-slate-100 ring-2 ring-gray-300 dark:ring-slate-600' : ''"
     >
-      <th:block th:text="'#'+${tagItem.spec.displayName}" />
+      <th:block th:text="|#${tagItem.spec.displayName}|" />
       <sup th:text="${tagItem.status.visiblePostCount}"></sup>
     </a>
   </div>

--- a/templates/modules/widgets/tags.html
+++ b/templates/modules/widgets/tags.html
@@ -21,7 +21,7 @@
       th:title="${tag.spec.displayName}"
       class="rounded bg-gray-100 px-1 py-0.5 text-sm text-gray-900 hover:bg-gray-200 dark:bg-slate-600 dark:text-slate-50 dark:hover:bg-slate-700 dark:hover:text-slate-100"
     >
-      <th:block th:text="'#'+${tag.spec.displayName}" />
+      <th:block th:text="|#${tag.spec.displayName}|" />
       <sup th:text="${tag.status.visiblePostCount}"></sup>
     </a>
   </div>

--- a/templates/page.html
+++ b/templates/page.html
@@ -26,11 +26,11 @@
             <div class="flex items-center gap-2 text-xs font-light text-gray-600 dark:text-slate-100">
               <span th:text="${'发布于 '+#dates.format(singlePage.spec.publishTime,'yyyy-MM-dd')}"></span>
               <span class="text-gray-300 dark:text-slate-200">/</span>
-              <span th:text="${singlePage.stats.visit}+' 阅读'"></span>
+              <span th:text="|${singlePage.stats?.visit ?:0} 阅读|"></span>
               <span class="text-gray-300 dark:text-slate-200">/</span>
-              <span th:text="${singlePage.stats.comment}+ ' 评论'"> </span>
+              <span th:text="|${singlePage.stats?.comment ?:0} 评论|"> </span>
               <span class="text-gray-300 dark:text-slate-200">/</span>
-              <span th:text="${singlePage.stats.upvote}+' 点赞'"> </span>
+              <span th:text="|${singlePage.stats?.upvote ?:0} 点赞|"> </span>
             </div>
           </div>
         </div>

--- a/templates/post.html
+++ b/templates/post.html
@@ -43,13 +43,13 @@
               th:text="${post.owner.displayName}"
             ></span>
             <div class="flex items-center gap-2 text-xs font-light text-gray-600 dark:text-slate-100">
-              <span th:text="${'发布于 '+#dates.format(post.spec.publishTime,'yyyy-MM-dd')}"></span>
+              <span th:text="|发布于 ${#dates.format(post.spec.publishTime,'yyyy-MM-dd')}|"></span>
               <span class="text-gray-300 dark:text-slate-200">/</span>
-              <span th:text="${post.stats.visit}+' 阅读'"></span>
+              <span th:text="|${post.stats?.visit ?:0} 阅读|"></span>
               <span class="text-gray-300 dark:text-slate-200">/</span>
-              <span th:text="${post.stats.comment}+ ' 评论'"> </span>
+              <span th:text="|${post.stats?.comment ?:0} 评论|"> </span>
               <span class="text-gray-300 dark:text-slate-200">/</span>
-              <span th:text="${post.stats.upvote}+' 点赞'"> </span>
+              <span th:text="|${post.stats?.upvote ?:0} 点赞|"> </span>
             </div>
           </div>
         </div>
@@ -75,7 +75,7 @@
           th:each="tag : ${post.tags}"
           th:href="@{${tag.status.permalink}}"
           th:title="${tag.spec.displayName}"
-          th:text="'#'+${tag.spec.displayName}"
+          th:text="|#${tag.spec.displayName}|"
           class="cursor-pointer text-sm italic text-gray-600 hover:text-gray-900 dark:text-slate-400 dark:hover:text-slate-500"
         >
         </a>

--- a/templates/tag.html
+++ b/templates/tag.html
@@ -13,7 +13,7 @@
       th:if="${posts.total gt 0}"
       th:with="postItems=${posts.items},list_layout=${theme.config.layout.post_list_layout}"
       class="mt-6 grid grid-cols-1 gap-6"
-      th:classappend="${list_layout == 'grid_3' ? 'md:grid-cols-2 xl:grid-cols-3' : ''} + ' ' + ${list_layout == 'grid_2' ? 'md:grid-cols-2' : ''}"
+      th:classappend="|${list_layout == 'grid_3' ? 'md:grid-cols-2 xl:grid-cols-3' : ''} ${list_layout == 'grid_2' ? 'md:grid-cols-2' : ''}|"
     >
       <th:block th:each="post : ${postItems}">
         <th:block
@@ -34,7 +34,7 @@
         <span class="i-tabler-arrow-left text-lg transition-all group-hover:-translate-x-1"></span>
         <span>上一页</span>
       </a>
-      <span class="text-sm text-gray-900 dark:text-slate-50" th:text="${posts.page} +' / '+ ${posts.totalPages}"></span>
+      <span class="text-sm text-gray-900 dark:text-slate-50" th:text="|${posts.page} / ${posts.totalPages}|"></span>
       <a
         th:href="@{${posts.nextUrl}}"
         class="whitespace-no-wrap group inline-flex items-center justify-center gap-1 rounded-md border border-gray-200 bg-white px-4 py-1 text-sm font-medium leading-6 text-gray-600 shadow-sm hover:bg-gray-50 focus:shadow-none focus:outline-none dark:border-slate-600 dark:bg-slate-700 dark:text-slate-100 dark:hover:bg-slate-600 dark:hover:text-white"

--- a/templates/tags.html
+++ b/templates/tags.html
@@ -15,7 +15,7 @@
           th:if="${posts.total gt 0}"
           th:with="postItems=${posts.items},list_layout=${theme.config.layout.post_list_layout}"
           class="mt-6 grid grid-cols-1 gap-6"
-          th:classappend="${list_layout == 'grid_3' ? 'md:grid-cols-2 xl:grid-cols-3' : ''} + ' ' + ${list_layout == 'grid_2' ? 'md:grid-cols-2' : ''}"
+          th:classappend="|${list_layout == 'grid_3' ? 'md:grid-cols-2 xl:grid-cols-3' : ''} ${list_layout == 'grid_2' ? 'md:grid-cols-2' : ''}|"
         >
           <th:block th:each="post : ${postItems}">
             <th:block


### PR DESCRIPTION
使用 Thymeleaf 的 [Literal substitutions](https://www.thymeleaf.org/doc/tutorials/2.1/usingthymeleaf.html#literal-substitutions) 特性优化 th:class 和 th:text 标签的字符串拼接写法，一定程度上可以让代码提升阅读性。它的写法类似于 JavaScript 的 [Template literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals)。

/kind improvement

```release-note
None
```