### PR TITLE
fix: links of links page are not bound url

### DIFF
--- a/templates/links.html
+++ b/templates/links.html
@@ -10,7 +10,7 @@
         <th:block th:each="group : ${groups}">
           <h2 class="mt-2 text-lg font-medium dark:text-slate-50" th:text="${group.spec.displayName}"></h2>
           <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-            <a th:each="link : ${group.links}" :key="i" href="#" target="_blank">
+            <a th:each="link : ${group.links}" th:href="${link.spec.url}" target="_blank">
               <div
                 class="relative flex items-center space-x-3 rounded border border-gray-300 bg-white px-5 py-4 shadow-sm hover:border-gray-400 hover:shadow dark:border-slate-600 dark:bg-slate-700 dark:hover:border-slate-700"
               >


### PR DESCRIPTION
修复链接页面（/links）的链接没有绑定访问地址的问题。

/kind bug

Fixes https://github.com/halo-dev/theme-earth/issues/35

```release-note
None
```