### PR TITLE
fix:  link overflow

### DIFF
--- a/templates/page.html
+++ b/templates/page.html
@@ -61,6 +61,7 @@
       <h1 class="my-3 text-2xl font-medium dark:text-slate-50" th:text="${singlePage.spec.title}"></h1>
       <article
         class="prose prose-base mt-4 !max-w-none dark:prose-invert"
+        style="word-wrap:break-word"
         th:utext="${singlePage.content.content}"
       ></article>
       <hr class="my-10 dark:border-slate-700" />

--- a/templates/post.html
+++ b/templates/post.html
@@ -99,6 +99,7 @@
       <article
         id="content"
         class="prose prose-base mt-4 !max-w-none prose-pre:p-0 dark:prose-invert"
+        style="word-wrap:break-word"
         th:utext="${post.content.content}"
       ></article>
       <div


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement

#### What this PR does / why we need it:

修复文章中链接过长溢出的问题。
<img width="1025" alt="image" src="https://user-images.githubusercontent.com/114651359/233283594-df11456e-ac8b-4e8f-a0bd-7c505c08802d.png">

#### Which issue(s) this PR fixes:

halo里的“当一个链接过长时，出现超越屏幕边界的问题” #3474
https://github.com/halo-dev/halo/issues/3474

#### Special notes for your reviewer:

发现问题好像是由于把整个链接看作了一个单词导致无法换行，加上css属性“word-wrap:break-word”，让他在找不到换行位置的时候也换行。

#### Does this PR introduce a user-facing change?

```release-note
none
```