### PR TITLE
fix the problem that the footer title does not display

### DIFF
--- a/templates/modules/footer.html
+++ b/templates/modules/footer.html
@@ -8,7 +8,7 @@
         th:alt="${site.title}"
       />
       <span class="self-center whitespace-nowrap text-2xl font-semibold dark:text-slate-50" 
-            th:text="${theme.config.footer.title != null and theme.config.footer.title != '' ? theme.config.footer.title : site.title}">
+            th:text="${theme.config.footer.title ?: site.title}">
       </span>
     </a>
     <th:block th:if="${not #strings.isEmpty(theme.config.footer.menu)}">
@@ -59,7 +59,7 @@
         />
         <span
           class="self-center whitespace-nowrap text-2xl font-semibold dark:text-slate-50"
-          th:text="${theme.config.footer.title != null and theme.config.footer.title != '' ? theme.config.footer.title : site.title}"
+          th:text="${theme.config.footer.title ?: site.title}"
         ></span>
       </a>
       <span

--- a/templates/modules/footer.html
+++ b/templates/modules/footer.html
@@ -7,7 +7,8 @@
         class="mr-3 h-8 w-8"
         th:alt="${site.title}"
       />
-      <span class="self-center whitespace-nowrap text-2xl font-semibold dark:text-slate-50" th:text="${site.title}">
+      <span class="self-center whitespace-nowrap text-2xl font-semibold dark:text-slate-50" 
+            th:text="${theme.config.footer.title != null and theme.config.footer.title != '' ? theme.config.footer.title : site.title}">
       </span>
     </a>
     <th:block th:if="${not #strings.isEmpty(theme.config.footer.menu)}">
@@ -58,7 +59,7 @@
         />
         <span
           class="self-center whitespace-nowrap text-2xl font-semibold dark:text-slate-50"
-          th:text="${site.title}"
+          th:text="${theme.config.footer.title != null and theme.config.footer.title != '' ? theme.config.footer.title : site.title}"
         ></span>
       </a>
       <span


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement

#### What this PR does / why we need it:

解决自定义页脚标题设置之后不生效的问题。
<img width="1270" alt="image" src="https://user-images.githubusercontent.com/114651359/233311128-22c000c5-5a4a-44b8-a909-3ddcfa483c77.png">
自定义页脚标题后，
<img width="1237" alt="image" src="https://user-images.githubusercontent.com/114651359/233311412-b2189223-57fd-4b4b-866b-fdae9568a991.png">

#### Which issue(s) this PR fixes:

Ref #69 

#### Special notes for your reviewer:

做了一个判断，若页脚标题设置了且不为空，则启用自定义的页脚标题，否则显示站点标题。

#### Does this PR introduce a user-facing change?

```release-note
none
```