### PR TITLE
feat: increased the length of the post toc widget

### DIFF
--- a/templates/post.html
+++ b/templates/post.html
@@ -21,7 +21,7 @@
         <span class="i-tabler-list text-lg"></span>
         目录
       </h2>
-      <div class="overflow-auto max-h-40 toc mt-2"></div>
+      <div class="overflow-auto max-h-64 toc mt-2"></div>
     </div>
   </th:block>
   <th:block th:fragment="sidebar">


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement

#### What this PR does / why we need it:

稍微加大了文章目录的长度。
<img width="317" alt="image" src="https://user-images.githubusercontent.com/114651359/236596800-a5aa4df4-cd09-4b70-a047-3e6c22900cd3.png">


#### Which issue(s) this PR fixes:

Fixes #77 

#### Special notes for your reviewer:

目录高度自适应，最大高度从max-h-40到max-h-64

#### Does this PR introduce a user-facing change?

```release-note
文章目录最大高度变大
```