### PR TITLE
fix: fix the post sidebar_prepend zindex

### DIFF
--- a/templates/post.html
+++ b/templates/post.html
@@ -15,7 +15,7 @@
   </th:block>
   <th:block th:fragment="sidebar_prepend">
     <div
-      class="z-5 sticky top-20 w-full cursor-pointer rounded-xl bg-white p-3 shadow transition-all duration-500 hover:shadow-md dark:bg-slate-800"
+      class="z-[5] sticky top-20 w-full cursor-pointer rounded-xl bg-white p-3 shadow transition-all duration-500 hover:shadow-md dark:bg-slate-800"
     >
       <h2 class="inline-flex items-center gap-2 text-base dark:text-slate-50">
         <span class="i-tabler-list text-lg"></span>


### PR DESCRIPTION
fix #84 

https://tailwindcss.com/docs/z-index#arbitrary-values
> If you need to use a one-off z-index value that doesn’t make sense to include in your theme, use square brackets to generate a property on the fly using any arbitrary value.
