### PR TITLE
fix: comment area anchor not working

### DIFF
--- a/templates/page.html
+++ b/templates/page.html
@@ -64,7 +64,7 @@
         th:utext="${singlePage.content.content}"
       ></article>
       <hr th:if="${haloCommentEnabled}" class="my-10 dark:border-slate-700" />
-      <div th:if="${haloCommentEnabled}">
+      <div id="comment" th:if="${haloCommentEnabled}">
         <h2 class="mb-2 text-base font-medium text-gray-900 dark:text-slate-50">评论</h2>
         <halo:comment
           group="content.halo.run"

--- a/templates/post.html
+++ b/templates/post.html
@@ -131,7 +131,7 @@
         </div>
       </div>
       <hr th:if="${haloCommentEnabled}" class="my-10 dark:border-slate-700" />
-      <div th:if="${haloCommentEnabled}">
+      <div id="comment" th:if="${haloCommentEnabled}">
         <h2 class="mb-2 text-base font-medium text-gray-900 dark:text-slate-50">评论</h2>
         <halo:comment
           group="content.halo.run"


### PR DESCRIPTION
修复文章和页面中点击评论图标无法跳转到评论区域的问题。

<img width="1099" alt="image" src="https://github.com/halo-dev/theme-earth/assets/21301288/577b5bfc-33d1-4eba-bc56-b181025fd8cb">

/kind bug

```release-note
修复文章和页面中点击评论图标无法跳转到评论区域的问题。
```