### PR TITLE
fix: post cover css

### DIFF
--- a/templates/modules/hero.html
+++ b/templates/modules/hero.html
@@ -40,8 +40,8 @@
   <th:block th:if="${theme.config.layout.content_header} and ${not #strings.isEmpty(cover)}">
     <div class="relative">
       <div
-        class="before:z-1 relative h-96 bg-cover bg-center bg-no-repeat before:absolute before:inset-0 before:bg-black/40 before:content-['*']"
-        th:style="'background-image: url('+${cover}+')'"
+        class="before:z-1 relative h-96 bg-cover bg-center bg-no-repeat before:absolute before:inset-0 before:bg-black/40"
+        th:style="|background-image: url('${cover}')|"
       ></div>
       <header
         class="pattern-header-text absolute top-1/2 mx-auto flex w-full flex-col items-center justify-center gap-3"


### PR DESCRIPTION
修复文章封面图包含一个 * 字符的问题。

<img width="658" alt="image" src="https://github.com/halo-dev/theme-earth/assets/21301288/1a8dbce7-0dd9-42e6-a48c-1abf1cb9c410">


/kind bug

```release-note
修复文章封面图包含了一个 * 字符的问题。
```