### PR TITLE
chore: cleanup inject code of comment widget

### DIFF
--- a/templates/moments.html
+++ b/templates/moments.html
@@ -38,7 +38,7 @@
             th:with="content=${moment.spec.content}"
             class="animated fadeIn flex w-full items-start gap-2 py-5"
           >
-            <img 
+            <img
               th:src="${moment.owner.avatar ?: #theme.assets('/images/default-avatar.svg')}"
               th:title="${moment.owner.displayName}"
               th:alt="${moment.owner.displayName}"
@@ -148,12 +148,7 @@
               </div>
 
               <div class="mt-2" x-show="showComment">
-                <halo:comment
-                  group="moment.halo.run"
-                  kind="Moment"
-                  th:attr="name=${moment.metadata.name}"
-                  colorScheme="window.main.currentColorScheme"
-                />
+                <halo:comment group="moment.halo.run" kind="Moment" th:attr="name=${moment.metadata.name}" />
               </div>
             </div>
           </li>

--- a/templates/page.html
+++ b/templates/page.html
@@ -71,12 +71,7 @@
       <hr th:if="${haloCommentEnabled}" class="my-10 dark:border-slate-700" />
       <div id="comment" th:if="${haloCommentEnabled}">
         <h2 class="mb-2 text-base font-medium text-gray-900 dark:text-slate-50">评论</h2>
-        <halo:comment
-          group="content.halo.run"
-          kind="SinglePage"
-          th:attr="name=${singlePage.metadata.name}"
-          colorScheme="window.main.currentColorScheme"
-        />
+        <halo:comment group="content.halo.run" kind="SinglePage" th:attr="name=${singlePage.metadata.name}" />
       </div>
     </div>
 

--- a/templates/post.html
+++ b/templates/post.html
@@ -157,12 +157,7 @@
       <hr th:if="${haloCommentEnabled}" class="my-10 dark:border-slate-700" />
       <div id="comment" th:if="${haloCommentEnabled}">
         <h2 class="mb-2 text-base font-medium text-gray-900 dark:text-slate-50">评论</h2>
-        <halo:comment
-          group="content.halo.run"
-          kind="Post"
-          th:attr="name=${post.metadata.name}"
-          colorScheme="window.main.currentColorScheme"
-        />
+        <halo:comment group="content.halo.run" kind="Post" th:attr="name=${post.metadata.name}" />
       </div>
     </div>
 


### PR DESCRIPTION
移除评论组件代码注入的 colorScheme 参数，在最新的评论插件中，已经可以通过 css 变量来控制配色，所以此参数不再有效。

/kind cleanup

```release-note
None
```