### PR TITLE
feat: add support for image formats to social media settings

### DIFF
--- a/templates/modules/footer-social.html
+++ b/templates/modules/footer-social.html
@@ -10,51 +10,11 @@
     </a>
     <span
       th:if="${social_media.url_type == 'image'}"
-      x-data="{openImageModal:false}"
+      th:attr="x-data=|{openImageModal:false,image: '${social_media.url}', alt: '${social_media.name}'}|"
       class="cursor-pointer text-gray-500 hover:text-gray-900 dark:hover:text-white"
     >
       <div th:classappend="${social_media.icon}" class="size-5" @click="openImageModal = true"></div>
-      <div>
-        <div
-          class="fixed inset-0 z-50 bg-gray-800/40 opacity-100 backdrop-blur-sm dark:bg-black/80"
-          aria-hidden="true"
-          x-show="openImageModal"
-          x-transition:enter="ease-in-out duration-300"
-          x-transition:enter-start="opacity-0"
-          x-transition:enter-end="opacity-100"
-          x-transition:leave="ease-in-out duration-300"
-          x-transition:leave-start="opacity-100"
-          x-transition:leave-end="opacity-0"
-        ></div>
-        <div
-          class="fixed inset-0 z-50 overflow-y-auto"
-          tabindex="-1"
-          x-show="openImageModal"
-          x-transition:enter="ease-out duration-200"
-          x-transition:enter-start="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
-          x-transition:enter-end="opacity-100 translate-y-0 sm:scale-100"
-          x-transition:leave="ease-in duration-100"
-          x-transition:leave-start="opacity-100 translate-y-0 sm:scale-100"
-          x-transition:leave-end="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
-        >
-          <div class="flex min-h-full flex-col items-center justify-center p-4 text-center sm:p-0">
-            <div
-              @click.outside="openImageModal = false"
-              class="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-sm sm:p-6"
-            >
-              <img th:src="${social_media.url}" />
-            </div>
-            <div>
-              <div
-                @click="openImageModal = false"
-                class="group inline-flex items-center justify-center rounded-full bg-white p-1.5"
-              >
-                <i class="i-tabler-x block text-gray-600 group-hover:text-gray-900"></i>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
+      <th:block th:replace="~{modules/image-view-modal}" />
     </span>
   </th:block>
 </div>

--- a/templates/modules/image-view-modal.html
+++ b/templates/modules/image-view-modal.html
@@ -1,0 +1,45 @@
+<template x-teleport="body">
+  <div>
+    <div
+      class="fixed inset-0 z-50 bg-gray-800/40 opacity-100 backdrop-blur-sm dark:bg-black/80"
+      aria-hidden="true"
+      x-show="openImageModal"
+      x-transition:enter="ease-in-out duration-300"
+      x-transition:enter-start="opacity-0"
+      x-transition:enter-end="opacity-100"
+      x-transition:leave="ease-in-out duration-300"
+      x-transition:leave-start="opacity-100"
+      x-transition:leave-end="opacity-0"
+    ></div>
+    <div
+      class="fixed inset-0 z-50 overflow-y-auto"
+      tabindex="-1"
+      x-show="openImageModal"
+      x-transition:enter="ease-out duration-200"
+      x-transition:enter-start="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+      x-transition:enter-end="opacity-100 translate-y-0 sm:scale-100"
+      x-transition:leave="ease-in duration-100"
+      x-transition:leave-start="opacity-100 translate-y-0 sm:scale-100"
+      x-transition:leave-end="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+    >
+      <div class="flex min-h-full flex-col items-center justify-center p-4 text-center sm:p-0">
+        <div
+          @click.outside="openImageModal = false"
+          class="relative my-4 transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all dark:bg-slate-800 dark:text-slate-100 sm:my-8 sm:w-full sm:max-w-sm sm:p-6"
+        >
+          <img :src="image" class="w-full" loading="lazy" :alt="alt" />
+        </div>
+        <div>
+          <div
+            @click="openImageModal = false"
+            class="group inline-flex items-center justify-center rounded-full bg-white p-1.5 dark:bg-slate-800"
+          >
+            <i
+              class="i-tabler-x block text-gray-600 hover:text-gray-900 dark:text-slate-100 dark:hover:text-slate-500"
+            ></i>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/templates/modules/widgets/profile.html
+++ b/templates/modules/widgets/profile.html
@@ -4,7 +4,13 @@
 >
   <div class="flex flex-col items-center justify-center gap-4">
     <div th:if="${not #strings.isEmpty(theme.config.sidebar.profile.logo)}" class="relative h-24 w-24">
-      <img th:src="${theme.config.sidebar.profile.logo}" th:alt="${site.title}" class="size-full rounded-full" />
+      <img
+        th:src="${theme.config.sidebar.profile.logo}"
+        th:alt="${site.title}"
+        width="96"
+        height="96"
+        class="size-full rounded-full object-cover"
+      />
     </div>
     <div><h1 class="text-2xl font-medium dark:text-slate-50" th:text="${site.title}"></h1></div>
     <div th:if="${not #strings.isEmpty(site.subtitle)}">
@@ -34,16 +40,31 @@
         ><span class="text-xs font-light text-gray-600 dark:text-slate-300">访问量</span>
       </div>
     </div>
-    <div th:with="social_medias = ${theme.config.sidebar.social_media}" class="grid grid-cols-6 items-center gap-5">
-      <a
-        th:each="social_media : ${social_medias}"
-        th:aria-label="${social_media.name}"
-        class="flex cursor-pointer items-center justify-center rounded p-1 hover:bg-gray-100 dark:hover:bg-slate-700"
-        th:href="${social_media.url}"
-        target="_blank"
-      >
-        <span class="text-gray-600 dark:text-slate-400" th:classappend="${social_media.icon}"></span>
-      </a>
+    <div
+      th:with="social_medias = ${theme.config.sidebar.social_media}"
+      class="flex flex-wrap items-center justify-center gap-5"
+    >
+      <th:block th:each="social_media : ${social_medias}">
+        <a
+          th:if="${social_media.url_type == 'normal'}"
+          th:aria-label="${social_media.name}"
+          class="flex cursor-pointer items-center justify-center rounded p-1 hover:bg-gray-100 dark:hover:bg-slate-700"
+          th:href="${social_media.url}"
+          target="_blank"
+        >
+          <span class="text-gray-600 dark:text-slate-400" th:classappend="${social_media.icon}"></span>
+        </a>
+
+        <span
+          th:if="${social_media.url_type == 'image'}"
+          th:attr="x-data=|{openImageModal:false,image: '${social_media.url}', alt: '${social_media.name}'}|"
+          class="flex cursor-pointer items-center justify-center rounded p-1 hover:bg-gray-100 dark:hover:bg-slate-700"
+          @click="openImageModal = true"
+        >
+          <div th:classappend="${social_media.icon}" class="text-gray-600 dark:text-slate-400"></div>
+          <th:block th:replace="~{modules/image-view-modal}" />
+        </span>
+      </th:block>
     </div>
   </div>
 </div>


### PR DESCRIPTION
侧边站点资料卡片的社交媒体支持图片形式的打开方式。

/kind feature

Fixes #133 

<img width="466" alt="image" src="https://github.com/halo-dev/theme-earth/assets/21301288/20a747b1-d423-4ccc-946a-80054bc9f158">
<img width="1008" alt="image" src="https://github.com/halo-dev/theme-earth/assets/21301288/ae5b0730-16d7-4d28-a88f-d643aa811591">

```release-note
侧边站点资料卡片的社交媒体支持图片形式的打开方式。
```