### PR TITLE
fix: resolve link display issue in share modal

### DIFF
--- a/templates/modules/share-modal.html
+++ b/templates/modules/share-modal.html
@@ -46,9 +46,12 @@
               <div
                 class="flex flex-wrap items-center justify-center gap-1 rounded-lg bg-gray-100 px-3 py-2 dark:bg-slate-700 sm:justify-between"
               >
-                <div class="select-all text-xs font-light text-gray-600 dark:text-slate-100" x-text="permalink"></div>
                 <div
-                  class="cursor-pointer select-none text-sm text-gray-600 hover:text-gray-900 dark:text-slate-400 dark:hover:text-slate-500"
+                  class="flex-1 select-all truncate text-xs font-light text-gray-600 dark:text-slate-100"
+                  x-text="permalink"
+                ></div>
+                <div
+                  class="flex-none cursor-pointer select-none text-sm text-gray-600 hover:text-gray-900 dark:text-slate-400 dark:hover:text-slate-500"
                   @click="handleCopy"
                   x-text="copied ? '已复制':'复制'"
                 ></div>


### PR DESCRIPTION
修复分享弹窗中链接过长导致的样式问题。

Fixes https://github.com/halo-dev/theme-earth/issues/141

<img width="609" alt="image" src="https://github.com/user-attachments/assets/e835a037-fff9-47e0-8374-667afe2a7c74">

/kind bug

```release-note
修复分享弹窗中链接过长导致的样式问题。
```