### PR TITLE
fix: resolve issue with default title text color not being applied

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -64,7 +64,7 @@ spec:
           id: title_color
           key: title_color
           label: 标题文字颜色
-          value: #ffffff
+          value: "#ffffff"
         - $formkit: checkbox
           name: content_header
           label: 显示文章页面顶部背景


### PR DESCRIPTION
Fixes #166 

```release-note
修复首屏标题文字颜色默认值不生效的问题。
```