### PR TITLE
feat: refine dark mode for menu divider

### DIFF
--- a/templates/modules/header.html
+++ b/templates/modules/header.html
@@ -42,7 +42,7 @@
             x-transition:leave="transition ease-in duration-75"
             x-transition:leave-start="transform opacity-100 scale-100"
             x-transition:leave-end="transform opacity-0 scale-95"
-            class="menu-dropdown absolute left-0 z-10 mt-2 w-40 divide-y divide-gray-50 overflow-hidden rounded bg-white shadow dark:bg-slate-700"
+            class="menu-dropdown absolute left-0 z-10 mt-2 w-40 divide-y divide-gray-50 overflow-hidden rounded bg-white shadow dark:divide-slate-600 dark:bg-slate-700"
           >
             <li
               th:each="childMenuItem : ${menuItem.children}"


### PR DESCRIPTION
为菜单子目录添加 `dark:divide-slate-600`，使其在暗色模式下表现正常

```release-note
None
```