### PR TITLE
feat: support dynamic html language attribute

### DIFF
--- a/templates/modules/layout.html
+++ b/templates/modules/layout.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" th:fragment="html (title,hero,content,head,footer,sidebar,contentClass)">
+<html th:lang="${#locale.toLanguageTag}" th:fragment="html (title,hero,content,head,footer,sidebar,contentClass)">
   <head>
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />


### PR DESCRIPTION
支持动态设置 HTML 的 lang 属性。

<img width="884" alt="image" src="https://github.com/user-attachments/assets/a6b56278-937a-4862-9292-589330a2b02a">
<img width="924" alt="image" src="https://github.com/user-attachments/assets/a7a2159c-4b97-43dc-9fdb-9e60dd3aa628">

BTW，这个改动只是暂时这样做，因为这个 lang 属性的定义可能是 publisher language，而不是根据用户访问的语言来确定，比如一个完全是中文内容的网站，如果设置为了 en，那么部分字符可能发生改变。不过 Halo 暂时没有设置发布语言的设置项，所以暂时这样做问题也不大。

/kind feature

```release-note
支持动态设置 HTML 的 lang 属性。
```