### PR TITLE
fix: add target attribute to footer menu links

### DIFF
--- a/templates/modules/footer.html
+++ b/templates/modules/footer.html
@@ -25,6 +25,7 @@
             th:href="@{${menuItem.status.href}}"
             class="transition-all hover:text-gray-900 hover:underline dark:hover:text-white"
             th:text="${menuItem.status.displayName}"
+            th:target="${menuItem.spec.target?.value}"
           ></a>
         </li>
       </ul>
@@ -111,6 +112,7 @@
                 th:href="@{${menuItem.status.href}}"
                 class="transition-all hover:text-gray-900 hover:underline dark:hover:text-white"
                 th:text="${menuItem.status.displayName}"
+                th:target="${menuItem.spec.target?.value}"
               ></a>
             </li>
           </ul>
@@ -135,6 +137,7 @@
                 th:href="@{${menuItem.status.href}}"
                 class="transition-all hover:text-gray-900 hover:underline dark:hover:text-white"
                 th:text="${menuItem.status.displayName}"
+                th:target="${menuItem.spec.target?.value}"
               ></a>
             </li>
           </ul>


### PR DESCRIPTION
修复页脚菜单项链接没有设置 target 的问题。

/kind bug

Fixes https://github.com/halo-dev/theme-earth/issues/202

```release-note
修复页脚菜单项链接没有设置 target 的问题。
```