### PR TITLE
fix: resolve sorting issue in popular posts widget

### DIFF
--- a/templates/modules/widgets/popular-posts.html
+++ b/templates/modules/widgets/popular-posts.html
@@ -6,7 +6,11 @@
     热门文章
   </h2>
   <div>
-    <ul role="list" class="divide-y divide-gray-100 dark:divide-slate-700" th:with="posts = ${postFinder.list(1,10)}">
+    <ul
+      role="list"
+      class="divide-y divide-gray-100 dark:divide-slate-700"
+      th:with="posts = ${postFinder.list({page: 1,size: 10,sort: {'stats.visit,desc'}})}"
+    >
       <li class="py-3" th:each="post : ${posts}">
         <div class="flex items-center justify-between">
           <div class="flex flex-col gap-1">
@@ -20,7 +24,7 @@
           </div>
           <div class="inline-flex items-center gap-1 text-xs text-gray-600 dark:text-slate-500">
             <span class="i-tabler-eye"></span>
-            <span th:text="${post.stats.visit}" class="tabular-nums"> </span>
+            <span th:text="${post.stats.visit ?: 0}" class="tabular-nums"> </span>
           </div>
         </div>
       </li>


### PR DESCRIPTION
适配 Halo 2.19 新的 `postFinder.list()` 接口，用于修复热门文章的排序问题。

Fixes https://github.com/halo-dev/theme-earth/issues/192

```release-note
适配 Halo 2.19 新的 `postFinder.list()` 接口，用于修复热门文章的排序问题。
```