### PR TITLE
fix: correct Chinese translation for pagination 'next page' text

### DIFF
--- a/i18n/zh_CN.properties
+++ b/i18n/zh_CN.properties
@@ -1,5 +1,5 @@
 common.previousPage=上一页
-common.nextPage=上一页
+common.nextPage=下一页
 common.more=更多
 common.all=全部
 common.noPosts=没有文章


### PR DESCRIPTION
修复中文语言中 `下一页` 的文字错误。

/kind bug

```release-note
修复中文语言中 `下一页` 的文字错误。
```