### PR TITLE
fix: update subtitle opacity for better visibility in hero module

### DIFF
--- a/templates/modules/hero.html
+++ b/templates/modules/hero.html
@@ -36,7 +36,7 @@
         <div class="mx-auto flex h-full max-w-7xl flex-col items-center justify-center gap-3 px-4 py-6 lg:px-6">
           <span class="text-5xl" th:style="|color:${theme.config.layout.title_color}|" th:text="${site.title}"></span>
           <span
-            class="text-sm font-light opacity-50"
+            class="text-sm font-light opacity-100"
             th:style="|color:${theme.config.layout.title_color}|"
             th:text="${site.subtitle}"
           ></span>

--- a/templates/modules/hero.html
+++ b/templates/modules/hero.html
@@ -36,7 +36,7 @@
         <div class="mx-auto flex h-full max-w-7xl flex-col items-center justify-center gap-3 px-4 py-6 lg:px-6">
           <span class="text-5xl" th:style="|color:${theme.config.layout.title_color}|" th:text="${site.title}"></span>
           <span
-            class="text-sm font-light opacity-100"
+            class="text-sm font-light"
             th:style="|color:${theme.config.layout.title_color}|"
             th:text="${site.subtitle}"
           ></span>


### PR DESCRIPTION
fix: update subtitle opacity for better visibility in hero module, close #129 

```release-note
修复首页副标题显示不明显的问题。
```