### PR TITLE
fix: resolve the issue of anchor link positioning not being offset

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -49,10 +49,7 @@ export function generateToc() {
       "group flex items-center justify-between rounded py-1 px-1.5 transition-all hover:bg-gray-100 text-sm opacity-80 dark:hover:bg-slate-700 dark:text-slate-50",
     collapseDepth: 6,
     headingsOffset: 100,
-    scrollSmooth: true,
-    scrollSmoothOffset: -100,
-    // @ts-ignore
-    tocScrollOffset: 50,
+    scrollSmooth: false,
   });
 }
 

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -2,6 +2,11 @@ body {
   overflow: overlay;
 }
 
+html {
+  scroll-padding-top: 100px;
+  scroll-behavior: smooth;
+}
+
 *::-webkit-scrollbar-track-piece {
   background-color: #f8f8f8;
   -webkit-border-radius: 2em;


### PR DESCRIPTION
Close: #227

移除 tocbot 初始化配置中关于滚动相关的配置，交给浏览器原生行为处理。可以解决使用锚点链接定位未偏移问题。

已在测试如下3中场景，均可正常跳转偏移：

- 直接通过URL访问带hash的链接
- 点击页面内的锚点链接
- 点击目录项

```release-note
修复直接访问文章无法使用目录定位的问题。
```