### PR TITLE
fix: correct offset for active toc item

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -50,6 +50,7 @@ export function generateToc() {
     collapseDepth: 6,
     headingsOffset: 100,
     scrollSmooth: false,
+    tocScrollOffset: 50,
   });
 }
 


### PR DESCRIPTION

![2025-01-06_15-12-38](https://github.com/user-attachments/assets/eeda6f2f-216d-42b7-ab5c-e50682bcba4f)

```release-note
修复文章目录激活项偏移错误的问题
``` 