### PR TITLE
fix: add null check for pagination element before adding event listener

### DIFF
--- a/templates/modules/pagination.html
+++ b/templates/modules/pagination.html
@@ -29,7 +29,13 @@
 
   <script th:inline="javascript">
     document.addEventListener("DOMContentLoaded", () => {
-      document.getElementById("pagination").addEventListener("change", (event) => {
+      const paginationSelect = document.getElementById("pagination");
+
+      if (!paginationSelect) {
+        return;
+      }
+
+      paginationSelect.addEventListener("change", (event) => {
         const selectedPage = event.target.value;
         window.location.href = `[(${context})]page/${selectedPage}`;
       });


### PR DESCRIPTION

![2025-01-06_15-48-10](https://github.com/user-attachments/assets/bd532417-750b-44e6-97db-0bbaef467467)

```release-note
修复在 pagination 不存在时添加事件监听器的问题
``` 