### PR TITLE
Refactor paginations

### DIFF
--- a/templates/archives.html
+++ b/templates/archives.html
@@ -74,26 +74,9 @@
         <span class="text-sm font-light text-gray-600" th:text="#{common.noPosts}"></span>
       </div>
 
-      <div class="mt-6 flex items-center justify-between" th:if="${archives.hasPrevious() || archives.hasNext()}">
-        <a
-          th:href="@{${archives.prevUrl}}"
-          class="whitespace-no-wrap group inline-flex items-center justify-center gap-1 rounded-md border border-gray-200 bg-white px-4 py-1 text-sm font-medium leading-6 text-gray-600 shadow-sm hover:bg-gray-50 focus:shadow-none focus:outline-none dark:border-slate-600 dark:bg-slate-700 dark:text-slate-100 dark:hover:bg-slate-600 dark:hover:text-white"
-        >
-          <span class="i-tabler-arrow-left text-lg transition-all group-hover:-translate-x-1"></span>
-          <span th:text="#{common.previousPage}"></span>
-        </a>
-        <span
-          class="text-sm text-gray-900 dark:text-slate-50"
-          th:text="|${archives.page} / ${archives.totalPages}|"
-        ></span>
-        <a
-          th:href="@{${archives.nextUrl}}"
-          class="whitespace-no-wrap group inline-flex items-center justify-center gap-1 rounded-md border border-gray-200 bg-white px-4 py-1 text-sm font-medium leading-6 text-gray-600 shadow-sm hover:bg-gray-50 focus:shadow-none focus:outline-none dark:border-slate-600 dark:bg-slate-700 dark:text-slate-100 dark:hover:bg-slate-600 dark:hover:text-white"
-        >
-          <span th:text="#{common.nextPage}"></span>
-          <span class="i-tabler-arrow-right text-lg transition-all group-hover:translate-x-1"></span>
-        </a>
-      </div>
+      <th:block
+        th:replace="~{modules/pagination :: pagination(context = '/archives/', prevUrl = ${archives.prevUrl}, nextUrl = ${archives.nextUrl}, totalPages = ${archives.totalPages}, page = ${archives.page}, hasPrevious = ${archives.hasPrevious()}, hasNext = ${archives.hasNext()})}"
+      />
     </div>
   </th:block>
 </html>

--- a/templates/categories.html
+++ b/templates/categories.html
@@ -26,15 +26,9 @@
         <div th:if="${posts.total == 0}" class="mt-6 flex items-center justify-center">
           <span class="text-sm font-light text-gray-600" th:text="#{common.noPosts}"></span>
         </div>
-        <div th:if="${posts.total gt 10}" class="mt-10 flex justify-end">
-          <a
-            class="group inline-flex items-center gap-2 truncate text-sm text-gray-600 hover:text-gray-900 dark:text-slate-100 dark:hover:text-slate-200"
-            th:href="@{${categories[0].status.permalink}}"
-          >
-            <span th:text="#{page.tags.morePosts}"></span>
-            <span class="i-tabler-chevron-right -translate-x-1 text-lg transition-all group-hover:translate-x-0"></span>
-          </a>
-        </div>
+        <th:block
+          th:replace="~{modules/pagination :: pagination(context = |${categories[0].status.permalink}/|, prevUrl = ${posts.prevUrl}, nextUrl = ${posts.nextUrl}, totalPages = ${posts.totalPages}, page = ${posts.page}, hasPrevious = ${posts.hasPrevious()}, hasNext = ${posts.hasNext()})}"
+        />
       </th:block>
     </th:block>
   </th:block>

--- a/templates/tags.html
+++ b/templates/tags.html
@@ -28,15 +28,9 @@
           <span class="text-sm font-light text-gray-600 dark:text-slate-200" th:text="#{common.noPosts}"></span>
         </div>
 
-        <div th:if="${posts.total gt 10}" class="mt-10 flex justify-end">
-          <a
-            class="group inline-flex items-center gap-2 truncate text-sm text-gray-600 hover:text-gray-900 dark:text-slate-100 dark:hover:text-slate-200"
-            th:href="@{${tag.status.permalink}}"
-          >
-            <span th:text="#{page.tags.morePosts}"></span>
-            <span class="i-tabler-chevron-right -translate-x-1 text-lg transition-all group-hover:translate-x-0"></span>
-          </a>
-        </div>
+        <th:block
+          th:replace="~{modules/pagination :: pagination(context = |${tag.status.permalink}/|, prevUrl = ${posts.prevUrl}, nextUrl = ${posts.nextUrl}, totalPages = ${posts.totalPages}, page = ${posts.page}, hasPrevious = ${posts.hasPrevious()}, hasNext = ${posts.hasNext()})}"
+        />
       </th:block>
     </th:block>
   </th:block>


### PR DESCRIPTION
为了提升代码的可维护性和一致性，将 tags.html、categories.html 和 archives.html 中的自定义分页逻辑替换为统一的分页模块。这样可以减少重复代码，并简化未来的维护工作。

```release-note
None
```