### PR TITLE
Adjust bottom margin of tag list on post page

### DIFF
--- a/templates/post.html
+++ b/templates/post.html
@@ -148,7 +148,7 @@
         class="mt-3 text-3xl font-medium dark:text-slate-50"
         th:text="${post.spec.title}"
       ></h1>
-      <div class="mt-3 flex gap-2">
+      <div class="my-3 flex gap-2">
         <a
           th:each="tag : ${post.tags}"
           th:href="@{${tag.status.permalink}}"


### PR DESCRIPTION
before:

<img width="760" height="278" alt="image" src="https://github.com/user-attachments/assets/9c94afe8-b9ea-4408-931d-8cd5e29ec9f0" />

after:

<img width="766" height="290" alt="image" src="https://github.com/user-attachments/assets/f61daf02-0400-41c2-b0cb-de73934012c2" />

```release-note
调整文章页面标签列表的下边距，以更好的适应内容。
```