### PR TITLE
feat: Add options to open post card and popular posts in new tab (#254)

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -180,6 +180,18 @@ spec:
             - label: 系统分享
               value: native
         - $formkit: checkbox
+          name: post_card_new_tab
+          id: post_card_new_tab
+          label: 文章卡片链接在新标签页打开
+          value: false
+          help: 控制文章列表页（如首页、分类页）的文章卡片链接是否在新标签页（_blank）打开。
+        - $formkit: checkbox
+          name: popular_posts_new_tab
+          id: popular_posts_new_tab
+          label: 热门文章链接在新标签页打开
+          value: false
+          help: 控制侧边栏的“热门文章”小部件中的文章链接是否在新标签页（_blank）打开。
+        - $formkit: checkbox
           name: show_deprecated_items
           key: show_deprecated_items
           id: show_deprecated_items

--- a/templates/modules/post-card.html
+++ b/templates/modules/post-card.html
@@ -55,7 +55,12 @@
         class="line-clamp-2 cursor-pointer text-2xl font-medium transition-all hover:text-gray-500 hover:underline dark:text-slate-50 dark:hover:text-white"
         th:classappend="|${direction == 'column' ? 'sm:line-clamp-2' : ''} ${list_layout == 'grid_2' ? 'sm:line-clamp-3' : ''} ${list_layout == 'grid_3' ? 'sm:line-clamp-4' : ''}|"
       >
-        <a th:href="@{${post.status.permalink}}" th:text="${post.spec.title}" th:title="${post.spec.title}"></a>
+        <a
+          th:href="@{${post.status.permalink}}"
+          th:text="${post.spec.title}"
+          th:title="${post.spec.title}"
+          th:attr="target=${theme.config.post.post_card_new_tab ? '_blank' : null}"
+        ></a>
       </h1>
       <p
         class="font-sm line-clamp-2 font-light dark:text-slate-200"

--- a/templates/modules/widgets/popular-posts.html
+++ b/templates/modules/widgets/popular-posts.html
@@ -15,7 +15,12 @@
         <div class="flex items-center justify-between">
           <div class="flex flex-col gap-1">
             <h3 class="line-clamp-2 text-sm font-medium hover:text-gray-500 hover:underline dark:text-slate-100">
-              <a th:text="${post.spec.title}" th:href="@{${post.status.permalink}}" th:title="${post.spec.title}"></a>
+              <a
+                th:text="${post.spec.title}"
+                th:href="@{${post.status.permalink}}"
+                th:title="${post.spec.title}"
+                th:attr="target=${theme.config.post.popular_posts_new_tab ? '_blank' : null}"
+              ></a>
             </h3>
             <p
               class="text-xs tabular-nums text-gray-500 dark:text-slate-400"


### PR DESCRIPTION
```release-note
新增文章列表卡片和热门文章小部件的配置项，允许用户控制链接是否在新标签页打开。
```
