### PR TITLE
fix: add control for content header

### DIFF
--- a/src/page.html
+++ b/src/page.html
@@ -4,7 +4,7 @@
     <script type="module" src="./assets/page.ts"></script>
   </template>
   <template name="hero">
-    <section th:unless="${#strings.isEmpty(singlePage.spec.cover)}">
+    <section th:if="${theme.config.layout.content_header}" th:unless="${#strings.isEmpty(singlePage.spec.cover)}">
       <div class="relative flex items-center" th:styleappend="|height:${theme.config.post.cover_height ?: '24rem'}|">
         <div
           class="before:z-1 relative size-full bg-cover bg-center bg-no-repeat before:absolute before:inset-0 before:bg-black/40"
@@ -96,7 +96,7 @@
           </div>
         </div>
         <h1
-          th:if="${#strings.isEmpty(singlePage.spec.cover)} or ${theme.config.post.title_position == 'content'}"
+          th:if="${#strings.isEmpty(singlePage.spec.cover)} or ${theme.config.post.title_position == 'content'} or ${not theme.config.layout.content_header}"
           class="my-3 text-3xl font-medium dark:text-slate-50"
           th:text="${singlePage.spec.title}"
         ></h1>

--- a/src/post.html
+++ b/src/post.html
@@ -8,7 +8,7 @@
     </script>
   </template>
   <template name="hero">
-    <section th:unless="${#strings.isEmpty(post.spec.cover)}">
+    <section th:if="${theme.config.layout.content_header}" th:unless="${#strings.isEmpty(post.spec.cover)}">
       <div class="relative flex items-center" th:styleappend="|height:${theme.config.post.cover_height ?: '24rem'}|">
         <div
           class="before:z-1 relative size-full bg-cover bg-center bg-no-repeat before:absolute before:inset-0 before:bg-black/40"
@@ -127,7 +127,7 @@
           </div>
         </div>
         <h1
-          th:if="${#strings.isEmpty(post.spec.cover)} or ${theme.config.post.title_position == 'content'}"
+          th:if="${#strings.isEmpty(post.spec.cover)} or ${theme.config.post.title_position == 'content'}  or ${not theme.config.layout.content_header}"
           class="mt-3 text-3xl font-medium dark:text-slate-50"
           th:text="${post.spec.title}"
         ></h1>


### PR DESCRIPTION
1. 为文章和页面的 hero 片段增加显示判断
2. 关闭顶部背景图时让标题显示在正文中

close #244
close #226

```release-note
修复无法控制文章页面顶部背景图的问题
``` 