### PR TITLE
Fix docsme docs page layout

### DIFF
--- a/src/docs.html
+++ b/src/docs.html
@@ -10,10 +10,11 @@
       <th:block th:replace="~{plugin:plugin-docsme:modules/script}" />
       <script type="module" src="./assets/doc.ts"></script>
     </template>
+
+    <div class="dm-container">
+      <th:block
+        th:replace="~{plugin:plugin-docsme:modules/docs :: docs (footer = null, showHeader = false, showThemeSwitcher = false)}"
+      />
+    </div>
   </include>
-  <div class="dm-container">
-    <th:block
-      th:replace="~{plugin:plugin-docsme:modules/docs :: docs (footer = null, showHeader = false, showThemeSwitcher = false)}"
-    />
-  </div>
 </th:block>


### PR DESCRIPTION
before
<img width="1047" height="879" alt="before" src="https://github.com/user-attachments/assets/2d4eebaf-46b2-45af-bdd6-7a87255093aa" />

after
<img width="913" height="798" alt="after" src="https://github.com/user-attachments/assets/fadf0f0f-17f1-4d6d-a6d0-144d680c91d0" />


```release-note
修复 Docsme 插件 docs 页面布局异常的问题
``` 