### PR TITLE
[codex] Add recommended apps for app store plugin

### DIFF
--- a/theme.yaml
+++ b/theme.yaml
@@ -6,6 +6,11 @@ metadata:
     # Add supports for Halo App Store
     # https://www.halo.run/store/apps/app-KgWqR
     "store.halo.run/app-id": "app-KgWqR"
+    # 链接管理：https://www.halo.run/store/apps/app-hfbQg
+    # 图库管理：https://www.halo.run/store/apps/app-BmQJW
+    # 瞬间：https://www.halo.run/store/apps/app-SnwWD
+    # Shiki 代码高亮：https://www.halo.run/store/apps/app-kzloktzn
+    # lightgallery.js 灯箱：https://www.halo.run/store/apps/app-OoggD
     "store.halo.run/recommended-apps": '["app-hfbQg", "app-BmQJW", "app-SnwWD", "app-kzloktzn", "app-OoggD"]'
 spec:
   displayName: Earth

--- a/theme.yaml
+++ b/theme.yaml
@@ -4,8 +4,9 @@ metadata:
   name: theme-earth
   annotations:
     # Add supports for Halo App Store
-    # https://halo.run/store/apps/app-KgWqR
+    # https://www.halo.run/store/apps/app-KgWqR
     "store.halo.run/app-id": "app-KgWqR"
+    "store.halo.run/recommended-apps": '["app-hfbQg", "app-BmQJW", "app-SnwWD", "app-kzloktzn", "app-OoggD"]'
 spec:
   displayName: Earth
   author:


### PR DESCRIPTION
## Summary
- Update the Halo App Store link to the canonical www.halo.run URL.
- Add recommended app metadata so the new app store plugin can show recommended apps after the theme is installed.

## Validation
- Parsed theme.yaml successfully with Ruby YAML loader.
- Ran git diff --check.